### PR TITLE
一言特殊符号bug,包含双引号和换行符时无法运行

### DIFF
--- a/src/controllers/hitokoto.js
+++ b/src/controllers/hitokoto.js
@@ -103,7 +103,7 @@ async function hitokoto (ctx, next) {
         break
       case 'js':
         const select = ctx.query.select ? ctx.query.select : '.hitokoto'
-        const response = `(function hitokoto(){var hitokoto="${sentence.hitokoto}";var dom=document.querySelector('${select}');Array.isArray(dom)?dom[0].innerText=hitokoto:dom.innerText=hitokoto;})()`
+        const response = `(function hitokoto(){var hitokoto=${JSON.stringify(sentence.hitokoto)};var dom=document.querySelector('${select}');Array.isArray(dom)?dom[0].innerText=hitokoto:dom.innerText=hitokoto;})()`
         if (gbk) {
           ctx.set('Content-Type', 'text/javascript; charset=gbk')
           ctx.body = iconv.encode(response, 'GBK')
@@ -146,7 +146,7 @@ async function hitokoto (ctx, next) {
         break
       case 'js':
         const select = ctx.query.select ? ctx.query.select : '.hitokoto'
-        const response = `(function hitokoto(){var hitokoto="${sentence.hitokoto}";var dom=document.querySelector('${select}');Array.isArray(dom)?dom[0].innerText=hitokoto:dom.innerText=hitokoto;})()`
+        const response = `(function hitokoto(){var hitokoto=${JSON.stringify(sentence.hitokoto)};var dom=document.querySelector('${select}');Array.isArray(dom)?dom[0].innerText=hitokoto:dom.innerText=hitokoto;})()`
         if (gbk) {
           ctx.set('Content-Type', 'text/javascript; charset=gbk')
           ctx.body = iconv.encode(response, 'GBK')


### PR DESCRIPTION
在微信机器人扩展首页 wxext.cn 使用了一言,可以打开测试下，有时候控制台有报错
发现是一言的字符串包含了双引号、换行符等特殊字符，把
var hitokoto="${sentence.hitokoto}";
修改成
var hitokoto=${JSON.stringify(sentence.hitokoto)};
完美解决