### PR TITLE
镜像名称错误问题

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   web:
-    image: hitokoto_api
+    image: hitokoto/api
     container_name: hitokoto_api
     hostname: hitokoto_api
     build: .


### PR DESCRIPTION
查阅镜像仓库，发现仓库名为 `hitokoto/api` 

https://hub.docker.com/r/hitokoto/api